### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_and_test:
+  build_and_test_nightly:
     name: rbrotli - latest
     runs-on: ubuntu-latest
     steps:
@@ -16,3 +16,11 @@ jobs:
       - run: rustup update nightly && rustup default nightly
       - run: cargo build --verbose
       - run: cargo test --verbose
+  build_and_test:
+    name: rbrotli - latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # automatically uses toolchain specified in rust-toolchain.toml
+      - run: cargo build --verbose
+      - run: cargo test --verbose # This will skip Miri since it's not nightly


### PR DESCRIPTION
Splits CI in two: one stays as it is, specifying the use of nightly, enabling Mir; and the other just uses whatever is specified in rust-toolchain.toml for everything else.

Enables https://github.com/google/rbrotli-enc/pull/6