### PR TITLE
Restore miri tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.'cfg(miri)']
+rustflags = [
+    "-C", "target-feature=+sse2,+ssse3,+sse4.1,+avx,+avx2"
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: swatinem/rust-cache@v2
       - run: cargo build --verbose
       - run: cargo test --verbose
+  miri_test:
+    name: rbrotli - latest - miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - uses: swatinem/rust-cache@v2
+      - run: cargo +nightly miri test --verbose

--- a/hugepage-buffer/src/lib.rs
+++ b/hugepage-buffer/src/lib.rs
@@ -71,17 +71,13 @@ unsafe fn allocate<T>(layout: Layout, zeroed: bool) -> *mut T {
     #[cfg(any(not(target_os = "linux"), miri))]
     {
         let ptr = if zeroed {
-            /// Safety:
-            /// The caller guarantees that layout is not zero sized
-            unsafe {
-                std::alloc::alloc_zeroed(layout)
-            }
+            // Safety:
+            // The caller guarantees that layout is not zero sized
+            unsafe { std::alloc::alloc_zeroed(layout) }
         } else {
-            /// Safety:
-            /// The caller guarantees that layout is not zero sized
-            unsafe {
-                std::alloc::alloc(layout)
-            }
+            // Safety:
+            // The caller guarantees that layout is not zero sized
+            unsafe { std::alloc::alloc(layout) }
         };
         assert_ne!(ptr, null_mut());
         ptr as *mut T

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -904,7 +904,9 @@ mod test {
     #[test]
     #[safe_arch_entrypoint("avx", "avx2")]
     fn test_ilog2() {
-        for i in 1..WSIZE {
+        let step = if cfg!(miri) { 1_000_000 } else { 1 };
+
+        for i in (1..WSIZE).step_by(step) {
             let simd =
                 _mm256_extract_epi32::<0>(_mm256_ilog2_epi32(_mm256_set1_epi32(i as i32))) as u32;
             assert_eq!(simd, i.ilog2());
@@ -914,8 +916,10 @@ mod test {
     #[test]
     #[safe_arch_entrypoint("avx", "avx2")]
     fn test_gain() {
-        for dist in 1u32..1024 {
-            for len in 4u32..2048 {
+        let step = if cfg!(miri) { 100 } else { 1 };
+
+        for dist in (1u32..1024).step_by(step) {
+            for len in (4u32..2048).step_by(step) {
                 let last_distances = [(dist + len) % 1024, dist.saturating_sub(len) % 1024];
                 let vdist = _mm256_set1_epi32(dist as i32);
                 let vlen = _mm256_set1_epi32(len as i32);
@@ -936,8 +940,11 @@ mod test {
     fn test_compute_context() {
         let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
         let mut data = [0; 256];
-        for i in 0..=255 {
-            for j in 0..=255 {
+
+        let step = if cfg!(miri) { 10 } else { 1 };
+
+        for i in (0..=255).step_by(step) {
+            for j in (0..=255).step_by(step) {
                 for x in 0..8 {
                     data[2 * x] = i;
                     data[2 * x + 1] = j;

--- a/lib/src/map_to_sym.rs
+++ b/lib/src/map_to_sym.rs
@@ -477,7 +477,10 @@ mod test {
         let mut distance_nbits_pat_buf = [0; 8];
         let mut distance_nbits_count_buf = [0; 8];
         let mut distance_sym_buf = [0; 8];
-        for d in 1..WSIZE {
+
+        let step = if cfg!(miri) { 1_000_000 } else { 1 };
+
+        for d in (1..WSIZE).step_by(step) {
             if d % 5 == 0 {
                 for i in 0..10 {
                     distances[i] = d as u32;
@@ -545,11 +548,14 @@ mod test {
         let mut nbits_pat_buf = [0; 8];
         let mut nbits_count_buf = [0; 8];
         let mut distance_ctx_buf = [0; 8];
-        for i in (0..METABLOCK_SIZE).step_by(8) {
+
+        let step = if cfg!(miri) { 8 * 1000 } else { 8 };
+
+        for i in (0..METABLOCK_SIZE).step_by(step) {
             if i > 22594 && i % 1024 != 0 {
                 continue;
             }
-            for j in (4..MAX_COPY_LEN).step_by(8) {
+            for j in (4..MAX_COPY_LEN).step_by(step) {
                 if j > 2118 && j % 1024 != 0 {
                     continue;
                 }
@@ -588,7 +594,10 @@ mod test {
         let mut sym_buf = [0; 8];
         let mut bits_buf = [0; 8];
         let mut nbits_buf = [0; 8];
-        for i in (0..METABLOCK_SIZE).step_by(8) {
+
+        let step = if cfg!(miri) { 8 * 1000 } else { 8 };
+
+        for i in (0..METABLOCK_SIZE).step_by(step) {
             for x in 0..8 {
                 insert[x] = (i + x) as u32;
             }
@@ -628,7 +637,10 @@ mod test {
         let mut sym_buf = [0; 8];
         let mut bits_buf = [0; 8];
         let mut nbits_buf = [0; 8];
-        for i in (2..METABLOCK_SIZE).step_by(8) {
+
+        let step = if cfg!(miri) { 8 * 1000 } else { 8 };
+
+        for i in (2..METABLOCK_SIZE).step_by(step) {
             for x in 0..8 {
                 copy[x] = (i + x) as u32;
             }


### PR DESCRIPTION
This PR restores miri test as well as adding caching for build dependencies to sped up CI.

Since miri's run time is so much slower than regular rust (especially when simulating SIMID instruction) I've significantly reduce the number of steps that tests check when running in miri. This will still allow miri to catch UB while leaving the actual logic testing for the regular `cargo test`.