### PR TITLE
Use one tree

### DIFF
--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -127,14 +127,14 @@ impl MetablockData {
         let literals = BoundedSlice::new_from_equal_array(&self.literals);
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
-        const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>() * 8;
-        let num = (count + 15) / SIZE_OF_LITERAL as u32;
+        const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>();
+        let num = (count + 15) / (SIZE_OF_LITERAL * 8) as u32;
         let start = (self.iac_literals as usize, self.num_syms.get());
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ LITERAL_BUF_SIZE - 32 }>,
-            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 }>,
+            BoundedUsize<{ LITERAL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
+            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
         )>::iter(start, num as usize, (32, 32))
         {
             let lits = safe_x86_64::_mm256_load(literals, idx);

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -47,8 +47,8 @@ struct LiteralHistogram {
 
 struct HistogramBuffers {
     iac_hist: BoxedHugePageArray<u32, IAC_HIST_BUF_SIZE>,
-    dist_hist: BoxedHugePageArray<[u32; MAX_DIST], 2>,
-    lit_hist: BoxedHugePageArray<LiteralHistogram, 64>,
+    dist_hist: [u32; MAX_DIST],
+    lit_hist: LiteralHistogram,
 }
 
 pub struct MetablockData {
@@ -64,135 +64,6 @@ pub struct MetablockData {
     iac_literals: u32,
     context_mode: ContextMode,
     num_syms: BoundedUsize<SYMBOL_BUF_LIMIT>,
-}
-
-#[target_feature(enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,avx,avx2")]
-fn histogram_distance(a: &LiteralHistogram, b: &LiteralHistogram) -> i32 {
-    if a.total == 0 || b.total == 0 {
-        return 0;
-    }
-    let inv_a = _mm256_set1_ps(1.0 / a.total as f32);
-    let inv_b = _mm256_set1_ps(1.0 / b.total as f32);
-    let inv_total = _mm256_set1_ps(1.0 / (a.total + b.total) as f32);
-    let mut total_distance0 = _mm256_setzero_si256();
-    let mut total_distance1 = _mm256_setzero_si256();
-    let mut total_distance2 = _mm256_setzero_si256();
-    let ceil_nlog2 = |x| {
-        _mm256_sub_epi32(
-            _mm256_set1_epi32(127),
-            _mm256_srli_epi32::<23>(_mm256_castps_si256(x)),
-        )
-    };
-    for i in BoundedUsize::<{ 256 - 8 }>::iter(0, 32, 8) {
-        let av = safe_x86_64::_mm256_load(BoundedSlice::new_from_equal_array(&a.data), i);
-        let bv = safe_x86_64::_mm256_load(BoundedSlice::new_from_equal_array(&b.data), i);
-        let totv = _mm256_add_epi32(av, bv);
-        let af32 = _mm256_cvtepi32_ps(av);
-        let bf32 = _mm256_cvtepi32_ps(bv);
-        let totf32 = _mm256_cvtepi32_ps(totv);
-        let proba = _mm256_mul_ps(af32, inv_a);
-        let probb = _mm256_mul_ps(bf32, inv_b);
-        let probtot = _mm256_mul_ps(totf32, inv_total);
-        let nbitsa = ceil_nlog2(proba);
-        let nbitsb = ceil_nlog2(probb);
-        let nbitstot = ceil_nlog2(probtot);
-        total_distance0 = _mm256_add_epi32(_mm256_mullo_epi32(nbitstot, totv), total_distance0);
-        total_distance1 = _mm256_add_epi32(_mm256_mullo_epi32(nbitsa, av), total_distance1);
-        total_distance2 = _mm256_add_epi32(_mm256_mullo_epi32(nbitsb, bv), total_distance2);
-    }
-    let mut total_distance = _mm256_sub_epi32(
-        total_distance0,
-        _mm256_add_epi32(total_distance1, total_distance2),
-    );
-    total_distance = _mm256_add_epi32(
-        total_distance,
-        _mm256_shuffle_epi32::<0b10110001>(total_distance),
-    );
-    total_distance = _mm256_add_epi32(
-        total_distance,
-        _mm256_shuffle_epi32::<0b01001110>(total_distance),
-    );
-    total_distance = _mm256_add_epi32(
-        total_distance,
-        _mm256_permute4x64_epi64::<0b01001110>(total_distance),
-    );
-    _mm256_extract_epi32::<0>(total_distance)
-}
-
-#[inline(never)]
-#[target_feature(enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,avx,avx2")]
-fn cluster_histograms(histograms: &[LiteralHistogram; 64]) -> (Vec<LiteralHistogram>, [u8; 64]) {
-    let mut used = [false; 64];
-    let mut cmap = [0; 64];
-    let mut output_histograms = Vec::with_capacity(64);
-
-    let best_histogram_index = histograms
-        .iter()
-        .enumerate()
-        .map(|(a, b)| (a, b.total))
-        .max_by_key(|(_, a)| *a)
-        .map(|(a, _)| a)
-        .unwrap();
-
-    output_histograms.push(histograms[best_histogram_index]);
-    used[best_histogram_index] = true;
-    cmap[best_histogram_index] = 0;
-
-    const MIN_HISTOGRAM_GAIN: i32 = 256;
-
-    let mut hd = [0i32; 64];
-    for i in 0..64 {
-        if !used[i] {
-            hd[i] = histogram_distance(&output_histograms[0], &histograms[i]);
-        }
-    }
-
-    loop {
-        let (best_histogram_index, gain) = hd
-            .iter()
-            .cloned()
-            .enumerate()
-            .max_by_key(|(_, a)| *a)
-            .unwrap();
-        if gain < MIN_HISTOGRAM_GAIN {
-            break;
-        }
-        cmap[best_histogram_index] = output_histograms.len() as u8;
-        output_histograms.push(histograms[best_histogram_index]);
-        used[best_histogram_index] = true;
-        for i in 0..64 {
-            if !used[i] {
-                hd[i] = hd[i].min(histogram_distance(
-                    output_histograms.last().unwrap(),
-                    &histograms[i],
-                ));
-            } else {
-                hd[i] = 0;
-            }
-        }
-    }
-
-    for i in 0..64 {
-        if used[i] {
-            continue;
-        }
-
-        let best_histogram_index = output_histograms
-            .iter()
-            .enumerate()
-            .map(|(a, h)| (a, histogram_distance(h, &histograms[i])))
-            .min_by_key(|(_, a)| *a)
-            .map(|(a, _)| a)
-            .unwrap();
-
-        cmap[i] = best_histogram_index as u8;
-        output_histograms[best_histogram_index].total += histograms[i].total;
-        for t in 0..MAX_LIT {
-            output_histograms[best_histogram_index].data[t] += histograms[i].data[t];
-        }
-    }
-
-    (output_histograms, cmap)
 }
 
 impl MetablockData {
@@ -250,19 +121,10 @@ impl MetablockData {
 
     #[inline]
     #[target_feature(enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,avx,avx2")]
-    fn add_literals(&mut self, count: u32, literals_cmap: &[u8; 64]) {
+    fn add_literals(&mut self, count: u32) {
         if count == 0 {
             return;
         }
-        let cmap = BoundedSlice::new_from_equal_array(literals_cmap);
-        let tbl0 = _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<0>::MAX));
-        let tbl1 =
-            _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<16>::MAX));
-        let tbl2 =
-            _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<32>::MAX));
-        let tbl3 =
-            _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<48>::MAX));
-
         let literals = BoundedSlice::new_from_equal_array(&self.literals);
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
@@ -276,22 +138,9 @@ impl MetablockData {
         )>::iter(start, num as usize, (16, 16))
         {
             let lits = safe_x86_64::_mm256_load(literals, idx);
-            let ctx_lookup_idx = _mm256_and_si256(_mm256_set1_epi8(0xF), lits);
-            let ctx0 = _mm256_shuffle_epi8(tbl0, ctx_lookup_idx);
-            let ctx1 = _mm256_shuffle_epi8(tbl1, ctx_lookup_idx);
-            let ctx2 = _mm256_shuffle_epi8(tbl2, ctx_lookup_idx);
-            let ctx3 = _mm256_shuffle_epi8(tbl3, ctx_lookup_idx);
-            let is13 = _mm256_slli_epi16::<3>(lits);
-            let is23 = _mm256_slli_epi16::<2>(lits);
-            let ctx01 = _mm256_blendv_epi8(ctx0, ctx1, is13);
-            let ctx23 = _mm256_blendv_epi8(ctx2, ctx3, is13);
-            let ctx_shifted = _mm256_and_si256(
-                _mm256_set1_epi16(0xFF00u16 as i16),
-                _mm256_blendv_epi8(ctx01, ctx23, is23),
-            );
             let val = _mm256_and_si256(lits, _mm256_set1_epi16(0xFF));
             let off = _mm256_set1_epi16((LIT_BASE + SYMBOL_MASK) as i16);
-            let res = _mm256_add_epi16(_mm256_add_epi16(off, val), ctx_shifted);
+            let res = _mm256_add_epi16(off, val);
             safe_x86_64::_mm256_store(syms, out_idx, res);
         }
         self.num_syms = self.num_syms.mod_add(count as usize);
@@ -324,8 +173,7 @@ impl MetablockData {
         distance_nbits_count_buf: &[u32; 8],
         distance_sym_buf: &[u32; 8],
         iac_hist_flat: &mut [u32; IAC_HIST_BUF_SIZE],
-        dist_hist_flat: &mut [u32; MAX_DIST * 2],
-        literals_cmap: &[u8; 64],
+        dist_hist_flat: &mut [u32; MAX_DIST],
     ) {
         let iac_sym_off = insert_and_copy_sym_buf[ii] as u16;
         *BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits).get_mut(self.num_syms) =
@@ -337,7 +185,7 @@ impl MetablockData {
             insert_and_copy_bits_buf[ii],
         );
 
-        self.add_literals(self.insert_len[i + ii], literals_cmap);
+        self.add_literals(self.insert_len[i + ii]);
 
         let dist_sym_off = distance_sym_buf[ii];
         *BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits).get_mut(self.num_syms) =
@@ -355,7 +203,7 @@ impl MetablockData {
             iac_sym_off as usize - SYMBOL_MASK as usize,
         )) += 1;
         *BoundedSlice::new_from_equal_array_mut(dist_hist_flat).get_mut(BoundedUsize::<
-            { MAX_DIST * 2 - 1 },
+            { MAX_DIST - 1 },
         >::new_masked(
             dist_sym_off as usize - (SYMBOL_MASK + DIST_BASE) as usize,
         )) += 1;
@@ -366,8 +214,7 @@ impl MetablockData {
     fn compute_symbols_and_icd_histograms(
         &mut self,
         iac_hist: &mut [u32; IAC_HIST_BUF_SIZE],
-        dist_hist: &mut [[u32; MAX_DIST]; 2],
-        literals_cmap: &[u8; 64],
+        dist_hist: &mut [u32; MAX_DIST],
     ) {
         let mut insert_and_copy_bits_buf = [0; 8];
         let mut insert_and_copy_nbits_pat_buf = [0; 8];
@@ -420,7 +267,6 @@ impl MetablockData {
                         &distance_sym_buf,
                         iac_hist,
                         transmute_mut!(dist_hist),
-                        literals_cmap,
                     );
                 }
             } else {
@@ -438,7 +284,6 @@ impl MetablockData {
                         &distance_sym_buf,
                         iac_hist,
                         transmute_mut!(dist_hist),
-                        literals_cmap,
                     );
                 }
             }
@@ -457,7 +302,7 @@ impl MetablockData {
                 last_iac_nbits -= last_iac_nbits.min(16);
                 self.num_syms = self.num_syms.mod_add(1);
             }
-            self.add_literals(remaining, literals_cmap);
+            self.add_literals(remaining);
         };
     }
 
@@ -564,42 +409,30 @@ impl MetablockData {
         };
 
         histo_buf.iac_hist.fill(0);
-        histo_buf.dist_hist[0].fill(0);
-        histo_buf.dist_hist[1].fill(0);
-        for i in 0..64 {
-            histo_buf.lit_hist[i].data.fill(0);
-            histo_buf.lit_hist[i].total = 0;
-        }
+        histo_buf.dist_hist.fill(0);
+        histo_buf.lit_hist.data.fill(0);
+        histo_buf.lit_hist.total = 0;
         let iac_hist = &mut histo_buf.iac_hist;
         let dist_hist = &mut histo_buf.dist_hist;
         let lit_hist = &mut histo_buf.lit_hist;
 
         for lit in &self.literals[..self.total_literals as usize] {
-            let lit_hist = BoundedSlice::new_from_equal_array_mut(lit_hist);
-            let histo = BoundedSlice::new_from_equal_array_mut(
-                &mut lit_hist.get_mut(lit.context.into()).data,
-            );
+            let histo = BoundedSlice::new_from_equal_array_mut(&mut lit_hist.data);
             *histo.get_mut(BoundedUsize::from_u8(lit.value)) += 1;
         }
-        for ctx in BoundedUsize::<63>::iter(0, 64, 1) {
-            let lit_hist = BoundedSlice::new_from_equal_array_mut(lit_hist);
-            let lh = lit_hist.get_mut(ctx);
-            lh.total = lh.data.iter().copied().sum::<u32>();
-        }
+        lit_hist.total = lit_hist.data.iter().copied().sum::<u32>();
 
-        let (mut clusters, cmap) = cluster_histograms(lit_hist);
-        if clusters.len() == 1 && clusters[0].data.iter().sum::<u32>() == 0 {
-            clusters[0].data[0] += 1;
+        // If we have no literal we still need a dummy huffman tree in the header to comply with the spec
+        if lit_hist.total == 0 {
+            lit_hist.data[0] += 1;
         }
 
         assert!(self.total_icd <= ICD_BUF_SIZE as u32 + 16);
 
-        self.compute_symbols_and_icd_histograms(iac_hist, dist_hist, &cmap[..].try_into().unwrap());
+        self.compute_symbols_and_icd_histograms(iac_hist, dist_hist);
 
-        for histo in dist_hist.iter_mut() {
-            if histo.iter().sum::<u32>() == 0 {
-                histo[0] = 1;
-            }
+        if dist_hist.iter().sum::<u32>() == 0 {
+            dist_hist[0] = 1;
         }
 
         let mut buf = &mut self.histogram_buf[..];
@@ -608,16 +441,12 @@ impl MetablockData {
         header.insert_and_copy_codes.push(code);
 
         header.distance_cmap = ContextMap::new(&[0, 0, 0, 1]);
-        for histo in dist_hist.iter_mut() {
-            (buf, code) = HuffmanCode::from_counts(histo, 15, buf);
-            header.distance_codes.push(code);
-        }
+        (buf, code) = HuffmanCode::from_counts(dist_hist, 15, buf);
+        header.distance_codes.push(code);
 
-        header.literals_cmap = ContextMap::new(&cmap);
-        for histo in clusters {
-            (buf, code) = HuffmanCode::from_counts(&histo.data, 15, buf);
-            header.literals_codes.push(code);
-        }
+        header.literals_cmap = ContextMap::new(&[0]);
+        (_, code) = HuffmanCode::from_counts(&lit_hist.data, 15, buf);
+        header.literals_codes.push(code);
         header.write(bw);
 
         self.write_bits(bw);
@@ -701,12 +530,12 @@ impl<
             ht: HashTable::new(),
             md: MetablockData::new(),
             hb: HistogramBuffers {
-                lit_hist: BoxedHugePageArray::new(LiteralHistogram {
+                lit_hist: LiteralHistogram {
                     data: [0; MAX_LIT],
                     total: 0,
-                }),
+                },
                 iac_hist: BoxedHugePageArray::new_zeroed(),
-                dist_hist: BoxedHugePageArray::new_zeroed(),
+                dist_hist: [0; MAX_DIST],
             },
             bwbuf: vec![],
         }

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -22,7 +22,7 @@ use crate::{
     metablock::{self, ContextMode},
 };
 use bounded_utils::safe_x86_64;
-use bounded_utils::{BoundedIterable, BoundedSlice, BoundedU8, BoundedUsize};
+use bounded_utils::{BoundedIterable, BoundedSlice, BoundedUsize};
 use hugepage_buffer::BoxedHugePageArray;
 use lsb_bitwriter::BitWriter;
 use safe_arch_macro::safe_arch_entrypoint;
@@ -36,7 +36,6 @@ use crate::constants::*;
 #[repr(C)]
 struct Literal {
     value: u8,
-    context: BoundedU8<63>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -99,8 +98,8 @@ impl MetablockData {
     }
 
     #[inline]
-    pub fn add_literal(&mut self, context: BoundedU8<63>, value: u8, do_add: bool) {
-        self.literals[self.total_literals as usize] = Literal { context, value };
+    pub fn add_literal(&mut self, value: u8, do_add: bool) {
+        self.literals[self.total_literals as usize] = Literal { value };
         self.total_literals += if do_add { 1 } else { 0 };
     }
 
@@ -128,14 +127,15 @@ impl MetablockData {
         let literals = BoundedSlice::new_from_equal_array(&self.literals);
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
-        let num = (count + 15) / 16;
+        const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>() * 8;
+        let num = (count + 15) / SIZE_OF_LITERAL as u32;
         let start = (self.iac_literals as usize, self.num_syms.get());
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ LITERAL_BUF_SIZE - 16 }>,
-            BoundedUsize<{ SYMBOL_BUF_SIZE - 16 }>,
-        )>::iter(start, num as usize, (16, 16))
+            BoundedUsize<{ LITERAL_BUF_SIZE - 32 }>,
+            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 }>,
+        )>::iter(start, num as usize, (32, 32))
         {
             let lits = safe_x86_64::_mm256_load(literals, idx);
             let val = _mm256_and_si256(lits, _mm256_set1_epi16(0xFF));

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -15,9 +15,7 @@
 use crate::compress::MetablockData;
 use crate::constants::*;
 use bounded_utils::safe_x86_64;
-use bounded_utils::{
-    bounded_u8_array, BoundedIterable, BoundedSlice, BoundedU32, BoundedU8, BoundedUsize,
-};
+use bounded_utils::{BoundedIterable, BoundedSlice, BoundedU32, BoundedU8, BoundedUsize};
 use hugepage_buffer::BoxedHugePageArray;
 use std::arch::x86_64::*;
 use zerocopy::FromZeroes;
@@ -298,29 +296,6 @@ fn table_search<
     (d, l, g, len12p_mask)
 }
 
-const CONTEXT_LUT0: [BoundedU8<63>; 256] = bounded_u8_array![
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    8, 12, 16, 12, 12, 20, 12, 16, 24, 28, 12, 12, 32, 12, 36, 12, 44, 44, 44, 44, 44, 44, 44, 44,
-    44, 44, 32, 32, 24, 40, 28, 12, 12, 48, 52, 52, 52, 48, 52, 52, 52, 48, 52, 52, 52, 52, 52, 48,
-    52, 52, 52, 52, 52, 48, 52, 52, 52, 52, 52, 24, 12, 28, 12, 12, 12, 56, 60, 60, 60, 56, 60, 60,
-    60, 56, 60, 60, 60, 60, 60, 56, 60, 60, 60, 60, 60, 56, 60, 60, 60, 60, 60, 24, 12, 28, 12, 0,
-    0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
-    0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
-    2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3,
-    2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3,
-];
-
-const CONTEXT_LUT1: [BoundedU8<63>; 256] = bounded_u8_array![
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
-    1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1,
-    1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-];
-
 const PRECOMPUTE_SIZE: usize = 16;
 
 #[inline]
@@ -521,12 +496,9 @@ impl<
         let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
         let mut hashes = [BoundedU32::constant::<0>(); PRECOMPUTE_SIZE];
 
-        let zero_ctx = BoundedU8::constant::<0>();
-
         let mut last_dist = 0;
         let mut last_len = 0;
         let mut last_gain = 0;
-        let mut last_ctx = zero_ctx;
         let mut last_lit = 0;
         let mut has_lazy = false;
 
@@ -585,25 +557,23 @@ impl<
                         gain,
                     )
                 };
-                let ctx = *BoundedSlice::new_from_equal_array(&context).get(po);
                 let lit = *data_slice.get(BoundedUsize::<{ CONTEXT_OFFSET + 1 }>::constant::<
                     CONTEXT_OFFSET,
                 >());
 
                 let (lit_params, copy_params) = if has_lazy && gain <= last_gain + GAIN_FOR_LAZY {
-                    let val = ((zero_ctx, 0, false), (last_len, last_dist, true));
+                    let val = ((0, false), (last_len, last_dist, true));
                     skip = last_len - 2;
                     has_lazy = false;
                     val
                 } else if gain > MIN_GAIN_FOR_GREEDY {
-                    let val = ((last_ctx, last_lit, has_lazy), (len, dist, true));
+                    let val = ((last_lit, has_lazy), (len, dist, true));
                     skip = len - 1;
                     has_lazy = false;
                     val
                 } else if len >= 4 {
-                    let val = ((last_ctx, last_lit, has_lazy), (0, 0, false));
+                    let val = ((last_lit, has_lazy), (0, 0, false));
                     last_lit = lit;
-                    last_ctx = ctx;
                     last_dist = dist;
                     last_len = len;
                     last_gain = gain;
@@ -611,9 +581,9 @@ impl<
                     val
                 } else {
                     debug_assert!(!has_lazy);
-                    ((ctx, lit, true), (0, 0, false))
+                    ((lit, true), (0, 0, false))
                 };
-                metablock_data.add_literal(lit_params.0, lit_params.1, lit_params.2);
+                metablock_data.add_literal(lit_params.0, lit_params.1);
                 metablock_data.add_copy(copy_params.0, copy_params.1, copy_params.2);
                 if USE_LAST_DISTANCES {
                     last_distances = if copy_params.2 {
@@ -703,10 +673,10 @@ impl<
         // slightly faster code.
         let mut bpos = start;
         if bpos == 0 {
-            metablock_data.add_literal(BoundedU8::constant::<0>(), data[0], true);
+            metablock_data.add_literal(data[0], true);
             bpos += 1;
             if bpos < data.len() {
-                metablock_data.add_literal(CONTEXT_LUT0[data[0] as usize], data[1], true);
+                metablock_data.add_literal(data[1], true);
                 bpos += 1;
             }
         }
@@ -719,10 +689,7 @@ impl<
             metablock_data,
         );
         while bpos < start + count {
-            let a = data[bpos - 1];
-            let b = data[bpos - 2];
-            let context = CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize];
-            metablock_data.add_literal(context, data[bpos], true);
+            metablock_data.add_literal(data[bpos], true);
             bpos += 1;
         }
         bpos - start
@@ -837,7 +804,7 @@ impl<
                 pos += 1;
                 ((lit, true), (0, 0, false))
             };
-            metablock_data.add_literal(BoundedU8::constant::<0>(), lit_params.0, lit_params.1);
+            metablock_data.add_literal(lit_params.0, lit_params.1);
             metablock_data.add_copy(copy_params.0, copy_params.1, copy_params.2);
             if USE_LAST_DISTANCES {
                 last_distances = if copy_params.2 {
@@ -869,7 +836,7 @@ impl<
             metablock_data,
         );
         while bpos < start + count {
-            metablock_data.add_literal(BoundedU8::constant::<0>(), data[bpos], true);
+            metablock_data.add_literal(data[bpos], true);
             bpos += 1;
         }
         bpos - start
@@ -880,7 +847,7 @@ impl<
 mod test {
     use super::{
         _mm256_ilog2_epi32, compute_context, gain_from_len_and_dist, gain_from_len_and_dist_simd,
-        CONTEXT_LUT0, CONTEXT_LUT1, PRECOMPUTE_SIZE,
+        PRECOMPUTE_SIZE,
     };
     use crate::constants::*;
     use bounded_utils::{BoundedSlice, BoundedU8};
@@ -921,30 +888,30 @@ mod test {
         }
     }
 
-    #[test]
-    #[safe_arch_entrypoint("sse2", "ssse3", "sse4.1", "avx", "avx2")]
-    fn test_compute_context() {
-        let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
-        let mut data = [0; 256];
-
-        let step = if cfg!(miri) { 10 } else { 1 };
-
-        for i in (0..=255).step_by(step) {
-            for j in (0..=255).step_by(step) {
-                for x in 0..8 {
-                    data[2 * x] = i;
-                    data[2 * x + 1] = j;
-                }
-                compute_context(BoundedSlice::new(&data).unwrap(), &mut context);
-                for x in 0..PRECOMPUTE_SIZE / 2 {
-                    let a = data[x + 1];
-                    let b = data[x];
-                    assert_eq!(
-                        context[x],
-                        CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize]
-                    );
-                }
-            }
-        }
-    }
+    // #[test]
+    // #[safe_arch_entrypoint("sse2", "ssse3", "sse4.1", "avx", "avx2")]
+    // fn test_compute_context() {
+    //     let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
+    //     let mut data = [0; 256];
+    //
+    //     let step = if cfg!(miri) { 10 } else { 1 };
+    //
+    //     for i in (0..=255).step_by(step) {
+    //         for j in (0..=255).step_by(step) {
+    //             for x in 0..8 {
+    //                 data[2 * x] = i;
+    //                 data[2 * x + 1] = j;
+    //             }
+    //             compute_context(BoundedSlice::new(&data).unwrap(), &mut context);
+    //             for x in 0..PRECOMPUTE_SIZE / 2 {
+    //                 let a = data[x + 1];
+    //                 let b = data[x];
+    //                 assert_eq!(
+    //                     context[x],
+    //                     CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize]
+    //                 );
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -887,31 +887,4 @@ mod test {
             }
         }
     }
-
-    // #[test]
-    // #[safe_arch_entrypoint("sse2", "ssse3", "sse4.1", "avx", "avx2")]
-    // fn test_compute_context() {
-    //     let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
-    //     let mut data = [0; 256];
-    //
-    //     let step = if cfg!(miri) { 10 } else { 1 };
-    //
-    //     for i in (0..=255).step_by(step) {
-    //         for j in (0..=255).step_by(step) {
-    //             for x in 0..8 {
-    //                 data[2 * x] = i;
-    //                 data[2 * x + 1] = j;
-    //             }
-    //             compute_context(BoundedSlice::new(&data).unwrap(), &mut context);
-    //             for x in 0..PRECOMPUTE_SIZE / 2 {
-    //                 let a = data[x + 1];
-    //                 let b = data[x];
-    //                 assert_eq!(
-    //                     context[x],
-    //                     CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize]
-    //                 );
-    //             }
-    //         }
-    //     }
-    // }
 }


### PR DESCRIPTION
Only use one huffman tree per type (literals, distances and insert/continue).

We can consider this pr as WIP because my every time I run cargo bench I get a different result so I don't actually know if this is any faster 🤷