### PR TITLE
Use just one huffman tree per type

### DIFF
--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -33,10 +33,8 @@ use zerocopy::{transmute, transmute_mut, AsBytes, FromZeroes};
 use crate::constants::*;
 
 #[derive(Debug, Clone, Copy, AsBytes, FromZeroes)]
-#[repr(C)]
-struct Literal {
-    value: u8,
-}
+#[repr(transparent)]
+pub struct Literal(u8);
 
 #[derive(Clone, Copy, Debug)]
 struct LiteralHistogram {
@@ -99,7 +97,7 @@ impl MetablockData {
 
     #[inline]
     pub fn add_literal(&mut self, value: u8, do_add: bool) {
-        self.literals[self.total_literals as usize] = Literal { value };
+        self.literals[self.total_literals as usize] = Literal(value);
         self.total_literals += if do_add { 1 } else { 0 };
     }
 
@@ -415,7 +413,7 @@ impl MetablockData {
 
         for lit in &self.literals[..self.total_literals as usize] {
             let histo = BoundedSlice::new_from_equal_array_mut(&mut lit_hist.data);
-            *histo.get_mut(BoundedUsize::from_u8(lit.value)) += 1;
+            *histo.get_mut(BoundedUsize::from_u8(lit.0)) += 1;
         }
         lit_hist.total = lit_hist.data.iter().copied().sum::<u32>();
 

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -127,14 +127,14 @@ impl MetablockData {
         let literals = BoundedSlice::new_from_equal_array(&self.literals);
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
-        const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>() * 8;
-        let num = (count + 15) / SIZE_OF_LITERAL as u32;
+        const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>();
+        let num = (count + 15) / (SIZE_OF_LITERAL * 8) as u32;
         let start = (self.iac_literals as usize, self.num_syms.get());
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ LITERAL_BUF_SIZE - 32 }>,
-            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 }>,
+            BoundedUsize<{ LITERAL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
+            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
         )>::iter(start, num as usize, (32, 32))
         {
             let lits = safe_x86_64::_mm256_load(literals, idx);

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -133,9 +133,9 @@ impl MetablockData {
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ LITERAL_BUF_SIZE - 16 / SIZE_OF_LITERAL }>,
-            BoundedUsize<{ SYMBOL_BUF_SIZE - 16 }>,
-        )>::iter(start, num as usize, (16, 16))
+            BoundedUsize<{ (LITERAL_BUF_SIZE - 32) / SIZE_OF_LITERAL }>,
+            BoundedUsize<{ (SYMBOL_BUF_SIZE - 32) / SIZE_OF_LITERAL }>,
+        )>::iter(start, num as usize, (32, 32))
         {
             let lits = safe_x86_64::_mm_load(literals, idx);
             let val = _mm256_cvtepu8_epi16(lits);
@@ -441,7 +441,7 @@ impl MetablockData {
         (buf, code) = HuffmanCode::from_counts(dist_hist, 15, buf);
         header.distance_codes.push(code);
 
-        header.literals_cmap = ContextMap::new(&[0]);
+        header.literals_cmap = ContextMap::new(&[0; 64]);
         (_, code) = HuffmanCode::from_counts(&lit_hist.data, 15, buf);
         header.literals_codes.push(code);
         header.write(bw);

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -128,17 +128,17 @@ impl MetablockData {
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
         const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>();
-        let num = (count + 15) / (SIZE_OF_LITERAL * 8) as u32;
+        let num = (count + 15) / 16;
         let start = (self.iac_literals as usize, self.num_syms.get());
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ LITERAL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
-            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
-        )>::iter(start, num as usize, (32, 32))
+            BoundedUsize<{ LITERAL_BUF_SIZE - 16 / SIZE_OF_LITERAL }>,
+            BoundedUsize<{ SYMBOL_BUF_SIZE - 16 }>,
+        )>::iter(start, num as usize, (16, 16))
         {
-            let lits = safe_x86_64::_mm256_load(literals, idx);
-            let val = _mm256_and_si256(lits, _mm256_set1_epi16(0xFF));
+            let lits = safe_x86_64::_mm_load(literals, idx);
+            let val = _mm256_cvtepu8_epi16(lits);
             let off = _mm256_set1_epi16((LIT_BASE + SYMBOL_MASK) as i16);
             let res = _mm256_add_epi16(off, val);
             safe_x86_64::_mm256_store(syms, out_idx, res);
@@ -220,7 +220,6 @@ impl MetablockData {
         let mut insert_and_copy_nbits_pat_buf = [0; 8];
         let mut insert_and_copy_nbits_count_buf = [0; 8];
         let mut insert_and_copy_sym_buf = [0; 8];
-        let mut distance_ctx_buf = [0; 8];
         let mut distance_bits_buf = [0; 8];
         let mut distance_nbits_pat_buf = [0; 8];
         let mut distance_nbits_count_buf = [0; 8];
@@ -240,12 +239,10 @@ impl MetablockData {
                 &mut insert_and_copy_bits_buf,
                 &mut insert_and_copy_nbits_pat_buf,
                 &mut insert_and_copy_nbits_count_buf,
-                &mut distance_ctx_buf,
             );
             distance_to_sym_and_bits_simd::<ICD_BUF_SIZE, ICD_BUF_LIMIT, { ICD_BUF_LIMIT + 2 }>(
                 BoundedSlice::new_from_equal_array(&self.distance),
                 i,
-                &distance_ctx_buf,
                 &mut distance_sym_buf,
                 &mut distance_bits_buf,
                 &mut distance_nbits_pat_buf,
@@ -440,7 +437,7 @@ impl MetablockData {
         (buf, code) = HuffmanCode::from_counts(&iac_hist[..MAX_IAC], 15, buf);
         header.insert_and_copy_codes.push(code);
 
-        header.distance_cmap = ContextMap::new(&[0, 0, 0, 1]);
+        header.distance_cmap = ContextMap::new(&[0, 0, 0, 0]);
         (buf, code) = HuffmanCode::from_counts(dist_hist, 15, buf);
         header.distance_codes.push(code);
 
@@ -634,7 +631,7 @@ impl<
         let mut virtual_start = 0;
         let mut pos = 0;
         while pos < data.len() {
-            self.md.reset(ContextMode::UTF8, pos == 0);
+            self.md.reset(ContextMode::Signed, pos == 0);
             pos += compress_one_metablock::<
                 ENTRY_SIZE,
                 ENTRY_SIZE_MINUS_ONE,

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -47,8 +47,8 @@ struct LiteralHistogram {
 
 struct HistogramBuffers {
     iac_hist: BoxedHugePageArray<u32, IAC_HIST_BUF_SIZE>,
-    dist_hist: BoxedHugePageArray<[u32; MAX_DIST], 2>,
-    lit_hist: BoxedHugePageArray<LiteralHistogram, 64>,
+    dist_hist: [u32; MAX_DIST],
+    lit_hist: LiteralHistogram,
 }
 
 pub struct MetablockData {
@@ -64,135 +64,6 @@ pub struct MetablockData {
     iac_literals: u32,
     context_mode: ContextMode,
     num_syms: BoundedUsize<SYMBOL_BUF_LIMIT>,
-}
-
-#[target_feature(enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,avx,avx2")]
-fn histogram_distance(a: &LiteralHistogram, b: &LiteralHistogram) -> i32 {
-    if a.total == 0 || b.total == 0 {
-        return 0;
-    }
-    let inv_a = _mm256_set1_ps(1.0 / a.total as f32);
-    let inv_b = _mm256_set1_ps(1.0 / b.total as f32);
-    let inv_total = _mm256_set1_ps(1.0 / (a.total + b.total) as f32);
-    let mut total_distance0 = _mm256_setzero_si256();
-    let mut total_distance1 = _mm256_setzero_si256();
-    let mut total_distance2 = _mm256_setzero_si256();
-    let ceil_nlog2 = |x| {
-        _mm256_sub_epi32(
-            _mm256_set1_epi32(127),
-            _mm256_srli_epi32::<23>(_mm256_castps_si256(x)),
-        )
-    };
-    for i in BoundedUsize::<{ 256 - 8 }>::iter(0, 32, 8) {
-        let av = safe_x86_64::_mm256_load(BoundedSlice::new_from_equal_array(&a.data), i);
-        let bv = safe_x86_64::_mm256_load(BoundedSlice::new_from_equal_array(&b.data), i);
-        let totv = _mm256_add_epi32(av, bv);
-        let af32 = _mm256_cvtepi32_ps(av);
-        let bf32 = _mm256_cvtepi32_ps(bv);
-        let totf32 = _mm256_cvtepi32_ps(totv);
-        let proba = _mm256_mul_ps(af32, inv_a);
-        let probb = _mm256_mul_ps(bf32, inv_b);
-        let probtot = _mm256_mul_ps(totf32, inv_total);
-        let nbitsa = ceil_nlog2(proba);
-        let nbitsb = ceil_nlog2(probb);
-        let nbitstot = ceil_nlog2(probtot);
-        total_distance0 = _mm256_add_epi32(_mm256_mullo_epi32(nbitstot, totv), total_distance0);
-        total_distance1 = _mm256_add_epi32(_mm256_mullo_epi32(nbitsa, av), total_distance1);
-        total_distance2 = _mm256_add_epi32(_mm256_mullo_epi32(nbitsb, bv), total_distance2);
-    }
-    let mut total_distance = _mm256_sub_epi32(
-        total_distance0,
-        _mm256_add_epi32(total_distance1, total_distance2),
-    );
-    total_distance = _mm256_add_epi32(
-        total_distance,
-        _mm256_shuffle_epi32::<0b10110001>(total_distance),
-    );
-    total_distance = _mm256_add_epi32(
-        total_distance,
-        _mm256_shuffle_epi32::<0b01001110>(total_distance),
-    );
-    total_distance = _mm256_add_epi32(
-        total_distance,
-        _mm256_permute4x64_epi64::<0b01001110>(total_distance),
-    );
-    _mm256_extract_epi32::<0>(total_distance)
-}
-
-#[inline(never)]
-#[target_feature(enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,avx,avx2")]
-fn cluster_histograms(histograms: &[LiteralHistogram; 64]) -> (Vec<LiteralHistogram>, [u8; 64]) {
-    let mut used = [false; 64];
-    let mut cmap = [0; 64];
-    let mut output_histograms = Vec::with_capacity(64);
-
-    let best_histogram_index = histograms
-        .iter()
-        .enumerate()
-        .map(|(a, b)| (a, b.total))
-        .max_by_key(|(_, a)| *a)
-        .map(|(a, _)| a)
-        .unwrap();
-
-    output_histograms.push(histograms[best_histogram_index]);
-    used[best_histogram_index] = true;
-    cmap[best_histogram_index] = 0;
-
-    const MIN_HISTOGRAM_GAIN: i32 = 256;
-
-    let mut hd = [0i32; 64];
-    for i in 0..64 {
-        if !used[i] {
-            hd[i] = histogram_distance(&output_histograms[0], &histograms[i]);
-        }
-    }
-
-    loop {
-        let (best_histogram_index, gain) = hd
-            .iter()
-            .cloned()
-            .enumerate()
-            .max_by_key(|(_, a)| *a)
-            .unwrap();
-        if gain < MIN_HISTOGRAM_GAIN {
-            break;
-        }
-        cmap[best_histogram_index] = output_histograms.len() as u8;
-        output_histograms.push(histograms[best_histogram_index]);
-        used[best_histogram_index] = true;
-        for i in 0..64 {
-            if !used[i] {
-                hd[i] = hd[i].min(histogram_distance(
-                    output_histograms.last().unwrap(),
-                    &histograms[i],
-                ));
-            } else {
-                hd[i] = 0;
-            }
-        }
-    }
-
-    for i in 0..64 {
-        if used[i] {
-            continue;
-        }
-
-        let best_histogram_index = output_histograms
-            .iter()
-            .enumerate()
-            .map(|(a, h)| (a, histogram_distance(h, &histograms[i])))
-            .min_by_key(|(_, a)| *a)
-            .map(|(a, _)| a)
-            .unwrap();
-
-        cmap[i] = best_histogram_index as u8;
-        output_histograms[best_histogram_index].total += histograms[i].total;
-        for t in 0..MAX_LIT {
-            output_histograms[best_histogram_index].data[t] += histograms[i].data[t];
-        }
-    }
-
-    (output_histograms, cmap)
 }
 
 impl MetablockData {
@@ -250,19 +121,10 @@ impl MetablockData {
 
     #[inline]
     #[target_feature(enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,avx,avx2")]
-    fn add_literals(&mut self, count: u32, literals_cmap: &[u8; 64]) {
+    fn add_literals(&mut self, count: u32) {
         if count == 0 {
             return;
         }
-        let cmap = BoundedSlice::new_from_equal_array(literals_cmap);
-        let tbl0 = _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<0>::MAX));
-        let tbl1 =
-            _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<16>::MAX));
-        let tbl2 =
-            _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<32>::MAX));
-        let tbl3 =
-            _mm256_broadcastsi128_si256(safe_x86_64::_mm_load(cmap, BoundedUsize::<48>::MAX));
-
         let literals = BoundedSlice::new_from_equal_array(&self.literals);
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
@@ -276,22 +138,9 @@ impl MetablockData {
         )>::iter(start, num as usize, (16, 16))
         {
             let lits = safe_x86_64::_mm256_load(literals, idx);
-            let ctx_lookup_idx = _mm256_and_si256(_mm256_set1_epi8(0xF), lits);
-            let ctx0 = _mm256_shuffle_epi8(tbl0, ctx_lookup_idx);
-            let ctx1 = _mm256_shuffle_epi8(tbl1, ctx_lookup_idx);
-            let ctx2 = _mm256_shuffle_epi8(tbl2, ctx_lookup_idx);
-            let ctx3 = _mm256_shuffle_epi8(tbl3, ctx_lookup_idx);
-            let is13 = _mm256_slli_epi16::<3>(lits);
-            let is23 = _mm256_slli_epi16::<2>(lits);
-            let ctx01 = _mm256_blendv_epi8(ctx0, ctx1, is13);
-            let ctx23 = _mm256_blendv_epi8(ctx2, ctx3, is13);
-            let ctx_shifted = _mm256_and_si256(
-                _mm256_set1_epi16(0xFF00u16 as i16),
-                _mm256_blendv_epi8(ctx01, ctx23, is23),
-            );
             let val = _mm256_and_si256(lits, _mm256_set1_epi16(0xFF));
             let off = _mm256_set1_epi16((LIT_BASE + SYMBOL_MASK) as i16);
-            let res = _mm256_add_epi16(_mm256_add_epi16(off, val), ctx_shifted);
+            let res = _mm256_add_epi16(off, val);
             safe_x86_64::_mm256_store(syms, out_idx, res);
         }
         self.num_syms = self.num_syms.mod_add(count as usize);
@@ -324,8 +173,7 @@ impl MetablockData {
         distance_nbits_count_buf: &[u32; 8],
         distance_sym_buf: &[u32; 8],
         iac_hist_flat: &mut [u32; IAC_HIST_BUF_SIZE],
-        dist_hist_flat: &mut [u32; MAX_DIST * 2],
-        literals_cmap: &[u8; 64],
+        dist_hist_flat: &mut [u32; MAX_DIST],
     ) {
         let iac_sym_off = insert_and_copy_sym_buf[ii] as u16;
         *BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits).get_mut(self.num_syms) =
@@ -337,7 +185,7 @@ impl MetablockData {
             insert_and_copy_bits_buf[ii],
         );
 
-        self.add_literals(self.insert_len[i + ii], literals_cmap);
+        self.add_literals(self.insert_len[i + ii]);
 
         let dist_sym_off = distance_sym_buf[ii];
         *BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits).get_mut(self.num_syms) =
@@ -355,7 +203,7 @@ impl MetablockData {
             iac_sym_off as usize - SYMBOL_MASK as usize,
         )) += 1;
         *BoundedSlice::new_from_equal_array_mut(dist_hist_flat).get_mut(BoundedUsize::<
-            { MAX_DIST * 2 - 1 },
+            { MAX_DIST - 1 },
         >::new_masked(
             dist_sym_off as usize - (SYMBOL_MASK + DIST_BASE) as usize,
         )) += 1;
@@ -366,8 +214,7 @@ impl MetablockData {
     fn compute_symbols_and_icd_histograms(
         &mut self,
         iac_hist: &mut [u32; IAC_HIST_BUF_SIZE],
-        dist_hist: &mut [[u32; MAX_DIST]; 2],
-        literals_cmap: &[u8; 64],
+        dist_hist: &mut [u32; MAX_DIST],
     ) {
         let mut insert_and_copy_bits_buf = [0; 8];
         let mut insert_and_copy_nbits_pat_buf = [0; 8];
@@ -420,7 +267,6 @@ impl MetablockData {
                         &distance_sym_buf,
                         iac_hist,
                         transmute_mut!(dist_hist),
-                        literals_cmap,
                     );
                 }
             } else {
@@ -438,7 +284,6 @@ impl MetablockData {
                         &distance_sym_buf,
                         iac_hist,
                         transmute_mut!(dist_hist),
-                        literals_cmap,
                     );
                 }
             }
@@ -457,7 +302,7 @@ impl MetablockData {
                 last_iac_nbits -= last_iac_nbits.min(16);
                 self.num_syms = self.num_syms.mod_add(1);
             }
-            self.add_literals(remaining, literals_cmap);
+            self.add_literals(remaining);
         };
     }
 
@@ -564,42 +409,30 @@ impl MetablockData {
         };
 
         histo_buf.iac_hist.fill(0);
-        histo_buf.dist_hist[0].fill(0);
-        histo_buf.dist_hist[1].fill(0);
-        for i in 0..64 {
-            histo_buf.lit_hist[i].data.fill(0);
-            histo_buf.lit_hist[i].total = 0;
-        }
+        histo_buf.dist_hist.fill(0);
+        histo_buf.lit_hist.data.fill(0);
+        histo_buf.lit_hist.total = 0;
         let iac_hist = &mut histo_buf.iac_hist;
         let dist_hist = &mut histo_buf.dist_hist;
         let lit_hist = &mut histo_buf.lit_hist;
 
         for lit in &self.literals[..self.total_literals as usize] {
-            let lit_hist = BoundedSlice::new_from_equal_array_mut(lit_hist);
-            let histo = BoundedSlice::new_from_equal_array_mut(
-                &mut lit_hist.get_mut(lit.context.into()).data,
-            );
+            let histo = BoundedSlice::new_from_equal_array_mut(&mut lit_hist.data);
             *histo.get_mut(BoundedUsize::from_u8(lit.value)) += 1;
         }
-        for ctx in BoundedUsize::<63>::iter(0, 64, 1) {
-            let lit_hist = BoundedSlice::new_from_equal_array_mut(lit_hist);
-            let lh = lit_hist.get_mut(ctx);
-            lh.total = lh.data.iter().copied().sum::<u32>();
-        }
+        lit_hist.total = lit_hist.data.iter().copied().sum::<u32>();
 
-        let (mut clusters, cmap) = cluster_histograms(lit_hist);
-        if clusters.len() == 1 && clusters[0].data.iter().sum::<u32>() == 0 {
-            clusters[0].data[0] += 1;
+        // If we have no literal we still need a dummy huffman tree in the header to comply with the spec
+        if lit_hist.total == 0 {
+            lit_hist.data[0] += 1;
         }
 
         assert!(self.total_icd <= ICD_BUF_SIZE as u32 + 16);
 
-        self.compute_symbols_and_icd_histograms(iac_hist, dist_hist, &cmap[..].try_into().unwrap());
+        self.compute_symbols_and_icd_histograms(iac_hist, dist_hist);
 
-        for histo in dist_hist.iter_mut() {
-            if histo.iter().sum::<u32>() == 0 {
-                histo[0] = 1;
-            }
+        if dist_hist.iter().sum::<u32>() == 0 {
+            dist_hist[0] = 1;
         }
 
         let mut buf = &mut self.histogram_buf[..];
@@ -608,16 +441,12 @@ impl MetablockData {
         header.insert_and_copy_codes.push(code);
 
         header.distance_cmap = ContextMap::new(&[0, 0, 0, 1]);
-        for histo in dist_hist.iter_mut() {
-            (buf, code) = HuffmanCode::from_counts(histo, 15, buf);
-            header.distance_codes.push(code);
-        }
+        (buf, code) = HuffmanCode::from_counts(dist_hist, 15, buf);
+        header.distance_codes.push(code);
 
-        header.literals_cmap = ContextMap::new(&cmap);
-        for histo in clusters {
-            (buf, code) = HuffmanCode::from_counts(&histo.data, 15, buf);
-            header.literals_codes.push(code);
-        }
+        header.literals_cmap = ContextMap::new(&[0]);
+        (_, code) = HuffmanCode::from_counts(&lit_hist.data, 15, buf);
+        header.literals_codes.push(code);
         header.write(bw);
 
         self.write_bits(bw);
@@ -701,12 +530,12 @@ impl<
             ht: HashTable::new(),
             md: MetablockData::new(),
             hb: HistogramBuffers {
-                lit_hist: BoxedHugePageArray::new(LiteralHistogram {
+                lit_hist: LiteralHistogram {
                     data: [0; MAX_LIT],
                     total: 0,
-                }),
+                },
                 iac_hist: BoxedHugePageArray::new_zeroed(),
-                dist_hist: BoxedHugePageArray::new_zeroed(),
+                dist_hist: [0; MAX_DIST],
             },
             bwbuf: vec![],
         }

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -22,7 +22,7 @@ use crate::{
     metablock::{self, ContextMode},
 };
 use bounded_utils::safe_x86_64;
-use bounded_utils::{BoundedIterable, BoundedSlice, BoundedU8, BoundedUsize};
+use bounded_utils::{BoundedIterable, BoundedSlice, BoundedUsize};
 use hugepage_buffer::BoxedHugePageArray;
 use lsb_bitwriter::BitWriter;
 use safe_arch_macro::safe_arch_entrypoint;
@@ -36,7 +36,6 @@ use crate::constants::*;
 #[repr(C)]
 struct Literal {
     value: u8,
-    context: BoundedU8<63>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -99,8 +98,8 @@ impl MetablockData {
     }
 
     #[inline]
-    pub fn add_literal(&mut self, context: BoundedU8<63>, value: u8, do_add: bool) {
-        self.literals[self.total_literals as usize] = Literal { context, value };
+    pub fn add_literal(&mut self, value: u8, do_add: bool) {
+        self.literals[self.total_literals as usize] = Literal { value };
         self.total_literals += if do_add { 1 } else { 0 };
     }
 
@@ -128,14 +127,15 @@ impl MetablockData {
         let literals = BoundedSlice::new_from_equal_array(&self.literals);
         let syms = BoundedSlice::new_from_equal_array_mut(&mut self.symbol_or_nbits);
 
-        let num = (count + 15) / 16;
+        const SIZE_OF_LITERAL: usize = std::mem::size_of::<Literal>() * 8;
+        let num = (count + 15) / SIZE_OF_LITERAL as u32;
         let start = (self.iac_literals as usize, self.num_syms.get());
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ LITERAL_BUF_SIZE - 16 }>,
-            BoundedUsize<{ SYMBOL_BUF_SIZE - 16 }>,
-        )>::iter(start, num as usize, (16, 16))
+            BoundedUsize<{ LITERAL_BUF_SIZE - 32 }>,
+            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 }>,
+        )>::iter(start, num as usize, (32, 32))
         {
             let lits = safe_x86_64::_mm256_load(literals, idx);
             let val = _mm256_and_si256(lits, _mm256_set1_epi16(0xFF));

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -133,9 +133,9 @@ impl MetablockData {
         // TODO(veluca): the checked_ operations in `::iter` cause a small but measurable slowdown
         // (~0.7% overall). The compiler could, in principle, figure out that they are not needed.
         for (idx, out_idx) in <(
-            BoundedUsize<{ (LITERAL_BUF_SIZE - 32) / SIZE_OF_LITERAL }>,
-            BoundedUsize<{ (SYMBOL_BUF_SIZE - 32) / SIZE_OF_LITERAL }>,
-        )>::iter(start, num as usize, (32, 32))
+            BoundedUsize<{ LITERAL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
+            BoundedUsize<{ SYMBOL_BUF_SIZE - 32 / SIZE_OF_LITERAL }>,
+        )>::iter(start, num as usize, (16, 16))
         {
             let lits = safe_x86_64::_mm_load(literals, idx);
             let val = _mm256_cvtepu8_epi16(lits);

--- a/lib/src/constants.rs
+++ b/lib/src/constants.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::compress::Literal;
+
 // File format choices.
 pub const METABLOCK_SIZE: usize = 1 << 22;
 pub const WBITS: usize = 24;
@@ -29,13 +31,13 @@ pub const LOG_MAX_DIST: i32 = 6;
 pub const MAX_DIST: usize = 1 << LOG_MAX_DIST;
 
 // Metablock-level buffers
-pub const LITERAL_BUF_SIZE: usize = METABLOCK_SIZE + 128;
+pub const LITERAL_BUF_SIZE: usize = METABLOCK_SIZE + (std::mem::size_of::<Literal>() * 128);
 pub const ICD_BUF_SIZE: usize = METABLOCK_SIZE / 4 + 128;
 
 // Using a larger buffer here allows speeding up a few bound checks. The memory overhead is
 // limited.
 pub const SYMBOL_BUF_LIMIT: usize = 1 << 24;
-pub const SYMBOL_BUF_SIZE: usize = SYMBOL_BUF_LIMIT + 16;
+pub const SYMBOL_BUF_SIZE: usize = SYMBOL_BUF_LIMIT + (std::mem::size_of::<Literal>() * 16);
 const _: () = assert!(ICD_BUF_SIZE * 6 + LITERAL_BUF_SIZE <= SYMBOL_BUF_SIZE);
 
 // Encoding for symbol writing

--- a/lib/src/constants.rs
+++ b/lib/src/constants.rs
@@ -40,8 +40,8 @@ const _: () = assert!(ICD_BUF_SIZE * 6 + LITERAL_BUF_SIZE <= SYMBOL_BUF_SIZE);
 
 // Encoding for symbol writing
 pub const DIST_BASE: u16 = MAX_IAC as u16;
-pub const LIT_BASE: u16 = DIST_BASE + MAX_DIST as u16 * 2;
-pub const MAX_SYM_COUNT: usize = LIT_BASE as usize + MAX_LIT * 64;
+pub const LIT_BASE: u16 = DIST_BASE + MAX_DIST as u16;
+pub const MAX_SYM_COUNT: usize = LIT_BASE as usize + MAX_LIT;
 pub const HISTOGRAM_BUF_SIZE: usize = if MAX_SYM_COUNT + MAX_IAC < (1 << 16) {
     1 << 16
 } else {

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -30,7 +30,6 @@ const LD_MAXDIFF: i32 = 3;
 const LD_OFF: i32 = 150;
 
 const INTERIOR_MARGIN: usize = 32;
-const CONTEXT_OFFSET: usize = 2;
 
 fn hash(data: u32) -> u32 {
     data.wrapping_mul(0x1E35A7BD) >> (32 - LOG_TABLE_SIZE)
@@ -300,81 +299,6 @@ const PRECOMPUTE_SIZE: usize = 16;
 
 #[inline]
 #[target_feature(enable = "sse2,ssse3,sse4.1,avx,avx2")]
-fn compute_context(
-    data_slice: &BoundedSlice<u8, { INTERIOR_MARGIN + CONTEXT_OFFSET }>,
-    context: &mut [BoundedU8<63>; PRECOMPUTE_SIZE],
-) {
-    let ctx_in = safe_x86_64::_mm_load(data_slice, BoundedUsize::<1>::constant::<0>());
-    // low 64 bits: data[-2], high 64 bits: data[-1].
-    let ctx_in_128 = _mm_shuffle_epi8(
-        ctx_in,
-        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7, 8),
-    );
-    let ctx_in = _mm256_broadcastsi128_si256(ctx_in_128);
-    let tbl1 = _mm256_setr_epi32(
-        0x00000000,
-        0x00100110,
-        0x00000000,
-        0x00000000,
-        0x43533432,
-        0x39383376,
-        0xbbbbbbbbu32 as i32,
-        0x37a688bb,
-    );
-    let tbl2 = _mm256_setr_epi32(
-        0xddcdddc3u32 as i32,
-        0xcdddddcdu32 as i32,
-        0xddcdddddu32 as i32,
-        0x33736ddd,
-        0xffefffe3u32 as i32,
-        0xefffffefu32 as i32,
-        0xffefffffu32 as i32,
-        0x03736fff,
-    );
-    let ctx_in_div2 =
-        _mm256_and_si256(_mm256_srli_epi16::<1>(ctx_in), _mm256_set1_epi8(0b01111111));
-    let ctx_lookup = _mm256_blendv_epi8(
-        _mm256_shuffle_epi8(tbl1, ctx_in_div2),
-        _mm256_shuffle_epi8(tbl2, ctx_in_div2),
-        _mm256_slli_epi16::<1>(ctx_in),
-    );
-    let high_nibble = _mm256_cmpeq_epi8(
-        _mm256_and_si256(ctx_in, _mm256_set1_epi8(1)),
-        _mm256_set1_epi8(1),
-    );
-    let ctx_lookup = _mm256_and_si256(
-        _mm256_blendv_epi8(ctx_lookup, _mm256_srli_epi16::<4>(ctx_lookup), high_nibble),
-        _mm256_set1_epi8(0xF),
-    );
-    let ctx0_low_div4 = _mm_blendv_epi8(
-        _mm256_extracti128_si256::<0>(ctx_lookup),
-        _mm256_extracti128_si256::<1>(ctx_lookup),
-        _mm_slli_epi16::<2>(ctx_in_128),
-    );
-    let ctx0_to_ctx1_low = _mm_setr_epi8(0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3);
-    let ctx1_low = _mm_shuffle_epi8(ctx0_to_ctx1_low, ctx0_low_div4);
-    let ctx0_low = _mm_slli_epi16::<2>(ctx0_low_div4);
-
-    let ctx0_hi = _mm_or_si128(
-        _mm_and_si128(ctx_in_128, _mm_set1_epi8(1)),
-        _mm_and_si128(_mm_srli_epi16::<5>(ctx_in_128), _mm_set1_epi8(2)),
-    );
-    let ctx1_hi = _mm_and_si128(
-        _mm_cmpgt_epi8(ctx_in_128, _mm_set1_epi8(-33)),
-        _mm_set1_epi8(2),
-    );
-    let ctx0 = _mm_blendv_epi8(ctx0_low, ctx0_hi, ctx_in_128);
-    let ctx1 = _mm_blendv_epi8(ctx1_low, ctx1_hi, ctx_in_128);
-    let ctx = _mm_or_si128(ctx1, _mm_alignr_epi8::<8>(ctx0, ctx0));
-    safe_x86_64::_mm_store_masked_u8(
-        BoundedSlice::new_from_equal_array_mut(context),
-        BoundedUsize::<0>::MAX,
-        ctx,
-    );
-}
-
-#[inline]
-#[target_feature(enable = "sse2,ssse3,sse4.1,avx,avx2")]
 fn compute_hash_at(
     data_slice: &BoundedSlice<u8, INTERIOR_MARGIN>,
     hashes: &mut [BoundedU32<{ TABLE_SIZE - 1 }>; PRECOMPUTE_SIZE],
@@ -418,20 +342,6 @@ fn compute_hash_at(
 }
 
 const TABLE_SIZE: usize = 1 << LOG_TABLE_SIZE;
-
-#[inline]
-#[target_feature(enable = "sse2,ssse3,sse4.1,avx,avx2")]
-fn compute_hash_and_context_at(
-    data_slice: &BoundedSlice<u8, { INTERIOR_MARGIN + CONTEXT_OFFSET }>,
-    context: &mut [BoundedU8<63>; PRECOMPUTE_SIZE],
-    hashes: &mut [BoundedU32<{ TABLE_SIZE - 1 }>; PRECOMPUTE_SIZE],
-) {
-    compute_hash_at(
-        data_slice.offset::<INTERIOR_MARGIN, CONTEXT_OFFSET>(),
-        hashes,
-    );
-    compute_context(data_slice, context);
-}
 
 pub struct HashTable<
     const ENTRY_SIZE: usize,
@@ -493,7 +403,6 @@ impl<
             return 0;
         }
 
-        let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
         let mut hashes = [BoundedU32::constant::<0>(); PRECOMPUTE_SIZE];
 
         let mut last_dist = 0;
@@ -504,20 +413,14 @@ impl<
 
         let mut last_distances = [0; 2];
 
-        debug_assert!(start >= CONTEXT_OFFSET);
-
         let mut skip = 0;
         for pos in start..end {
             let data_slice =
-                BoundedSlice::<_, { INTERIOR_MARGIN + CONTEXT_OFFSET }>::new_at_offset(
-                    data,
-                    pos - CONTEXT_OFFSET,
-                )
-                .unwrap();
+                BoundedSlice::<_, { INTERIOR_MARGIN }>::new_at_offset(data, pos).unwrap();
 
             let po = BoundedUsize::<{ PRECOMPUTE_SIZE / 2 - 1 }>::new_masked(pos - start);
             if po.get() == 0 {
-                compute_hash_and_context_at(data_slice, &mut context, &mut hashes);
+                compute_hash_at(data_slice, &mut hashes);
             }
 
             self.prefetch_pos(
@@ -526,8 +429,7 @@ impl<
                 .into(),
             );
 
-            let (chunk1, chunk2, chunk3) =
-                get_chunks(data_slice.offset::<INTERIOR_MARGIN, CONTEXT_OFFSET>());
+            let (chunk1, chunk2, chunk3) = get_chunks(data_slice);
             let hash = (*BoundedSlice::new_from_equal_array(&hashes).get(po)).into();
             let table = BoundedSlice::new_from_equal_array_mut(&mut self.table).get_mut(hash);
             let replacement_idx =
@@ -557,9 +459,7 @@ impl<
                         gain,
                     )
                 };
-                let lit = *data_slice.get(BoundedUsize::<{ CONTEXT_OFFSET + 1 }>::constant::<
-                    CONTEXT_OFFSET,
-                >());
+                let lit = *data_slice.get(BoundedUsize::<0>::MAX);
 
                 let (lit_params, copy_params) = if has_lazy && gain <= last_gain + GAIN_FOR_LAZY {
                     let val = ((0, false), (last_len, last_dist, true));
@@ -614,15 +514,11 @@ impl<
         let skip_end = end_upper_bound.min(end + skip as usize);
         for pos in end..skip_end {
             let data_slice =
-                BoundedSlice::<_, { INTERIOR_MARGIN + CONTEXT_OFFSET }>::new_at_offset(
-                    data,
-                    pos - CONTEXT_OFFSET,
-                )
-                .unwrap();
+                BoundedSlice::<_, { INTERIOR_MARGIN }>::new_at_offset(data, pos).unwrap();
 
             let po = BoundedUsize::<{ PRECOMPUTE_SIZE / 2 - 1 }>::new_masked(pos - start);
             if po.get() == 0 {
-                compute_hash_and_context_at(data_slice, &mut context, &mut hashes);
+                compute_hash_at(data_slice, &mut hashes);
             }
 
             self.prefetch_pos(
@@ -631,8 +527,7 @@ impl<
                 .into(),
             );
 
-            let (chunk1, chunk2, chunk3) =
-                get_chunks(data_slice.offset::<INTERIOR_MARGIN, CONTEXT_OFFSET>());
+            let (chunk1, chunk2, chunk3) = get_chunks(data_slice);
             let hash = (*BoundedSlice::new_from_equal_array(&hashes).get(po)).into();
             let table = BoundedSlice::new_from_equal_array_mut(&mut self.table).get_mut(hash);
             let replacement_idx =
@@ -672,14 +567,6 @@ impl<
         // TODO(veluca): for some reason, not enabling target features on this function results in
         // slightly faster code.
         let mut bpos = start;
-        if bpos == 0 {
-            metablock_data.add_literal(data[0], true);
-            bpos += 1;
-            if bpos < data.len() {
-                metablock_data.add_literal(data[1], true);
-                bpos += 1;
-            }
-        }
         bpos += self.parse_and_emit_interior::<MIN_GAIN_FOR_GREEDY, USE_LAST_DISTANCES>(
             data,
             bpos,

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -15,9 +15,7 @@
 use crate::compress::MetablockData;
 use crate::constants::*;
 use bounded_utils::safe_x86_64;
-use bounded_utils::{
-    bounded_u8_array, BoundedIterable, BoundedSlice, BoundedU32, BoundedU8, BoundedUsize,
-};
+use bounded_utils::{BoundedIterable, BoundedSlice, BoundedU32, BoundedU8, BoundedUsize};
 use hugepage_buffer::BoxedHugePageArray;
 use std::arch::x86_64::*;
 use zerocopy::FromZeroes;
@@ -298,29 +296,6 @@ fn table_search<
     (d, l, g, len12p_mask)
 }
 
-const CONTEXT_LUT0: [BoundedU8<63>; 256] = bounded_u8_array![
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    8, 12, 16, 12, 12, 20, 12, 16, 24, 28, 12, 12, 32, 12, 36, 12, 44, 44, 44, 44, 44, 44, 44, 44,
-    44, 44, 32, 32, 24, 40, 28, 12, 12, 48, 52, 52, 52, 48, 52, 52, 52, 48, 52, 52, 52, 52, 52, 48,
-    52, 52, 52, 52, 52, 48, 52, 52, 52, 52, 52, 24, 12, 28, 12, 12, 12, 56, 60, 60, 60, 56, 60, 60,
-    60, 56, 60, 60, 60, 60, 60, 56, 60, 60, 60, 60, 60, 56, 60, 60, 60, 60, 60, 24, 12, 28, 12, 0,
-    0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
-    0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
-    2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3,
-    2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3,
-];
-
-const CONTEXT_LUT1: [BoundedU8<63>; 256] = bounded_u8_array![
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
-    1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1,
-    1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-];
-
 const PRECOMPUTE_SIZE: usize = 16;
 
 #[inline]
@@ -521,12 +496,9 @@ impl<
         let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
         let mut hashes = [BoundedU32::constant::<0>(); PRECOMPUTE_SIZE];
 
-        let zero_ctx = BoundedU8::constant::<0>();
-
         let mut last_dist = 0;
         let mut last_len = 0;
         let mut last_gain = 0;
-        let mut last_ctx = zero_ctx;
         let mut last_lit = 0;
         let mut has_lazy = false;
 
@@ -585,25 +557,23 @@ impl<
                         gain,
                     )
                 };
-                let ctx = *BoundedSlice::new_from_equal_array(&context).get(po);
                 let lit = *data_slice.get(BoundedUsize::<{ CONTEXT_OFFSET + 1 }>::constant::<
                     CONTEXT_OFFSET,
                 >());
 
                 let (lit_params, copy_params) = if has_lazy && gain <= last_gain + GAIN_FOR_LAZY {
-                    let val = ((zero_ctx, 0, false), (last_len, last_dist, true));
+                    let val = ((0, false), (last_len, last_dist, true));
                     skip = last_len - 2;
                     has_lazy = false;
                     val
                 } else if gain > MIN_GAIN_FOR_GREEDY {
-                    let val = ((last_ctx, last_lit, has_lazy), (len, dist, true));
+                    let val = ((last_lit, has_lazy), (len, dist, true));
                     skip = len - 1;
                     has_lazy = false;
                     val
                 } else if len >= 4 {
-                    let val = ((last_ctx, last_lit, has_lazy), (0, 0, false));
+                    let val = ((last_lit, has_lazy), (0, 0, false));
                     last_lit = lit;
-                    last_ctx = ctx;
                     last_dist = dist;
                     last_len = len;
                     last_gain = gain;
@@ -611,9 +581,9 @@ impl<
                     val
                 } else {
                     debug_assert!(!has_lazy);
-                    ((ctx, lit, true), (0, 0, false))
+                    ((lit, true), (0, 0, false))
                 };
-                metablock_data.add_literal(lit_params.0, lit_params.1, lit_params.2);
+                metablock_data.add_literal(lit_params.0, lit_params.1);
                 metablock_data.add_copy(copy_params.0, copy_params.1, copy_params.2);
                 if USE_LAST_DISTANCES {
                     last_distances = if copy_params.2 {
@@ -703,10 +673,10 @@ impl<
         // slightly faster code.
         let mut bpos = start;
         if bpos == 0 {
-            metablock_data.add_literal(BoundedU8::constant::<0>(), data[0], true);
+            metablock_data.add_literal(data[0], true);
             bpos += 1;
             if bpos < data.len() {
-                metablock_data.add_literal(CONTEXT_LUT0[data[0] as usize], data[1], true);
+                metablock_data.add_literal(data[1], true);
                 bpos += 1;
             }
         }
@@ -719,10 +689,7 @@ impl<
             metablock_data,
         );
         while bpos < start + count {
-            let a = data[bpos - 1];
-            let b = data[bpos - 2];
-            let context = CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize];
-            metablock_data.add_literal(context, data[bpos], true);
+            metablock_data.add_literal(data[bpos], true);
             bpos += 1;
         }
         bpos - start
@@ -837,7 +804,7 @@ impl<
                 pos += 1;
                 ((lit, true), (0, 0, false))
             };
-            metablock_data.add_literal(BoundedU8::constant::<0>(), lit_params.0, lit_params.1);
+            metablock_data.add_literal(lit_params.0, lit_params.1);
             metablock_data.add_copy(copy_params.0, copy_params.1, copy_params.2);
             if USE_LAST_DISTANCES {
                 last_distances = if copy_params.2 {
@@ -869,7 +836,7 @@ impl<
             metablock_data,
         );
         while bpos < start + count {
-            metablock_data.add_literal(BoundedU8::constant::<0>(), data[bpos], true);
+            metablock_data.add_literal(data[bpos], true);
             bpos += 1;
         }
         bpos - start
@@ -880,7 +847,7 @@ impl<
 mod test {
     use super::{
         _mm256_ilog2_epi32, compute_context, gain_from_len_and_dist, gain_from_len_and_dist_simd,
-        CONTEXT_LUT0, CONTEXT_LUT1, PRECOMPUTE_SIZE,
+        PRECOMPUTE_SIZE,
     };
     use crate::constants::*;
     use bounded_utils::{BoundedSlice, BoundedU8};
@@ -921,30 +888,30 @@ mod test {
         }
     }
 
-    #[test]
-    #[safe_arch_entrypoint("sse2", "ssse3", "sse4.1", "avx", "avx2")]
-    fn test_compute_context() {
-        let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
-        let mut data = [0; 256];
-
-        let step = if cfg!(miri) { 10 } else { 1 };
-
-        for i in (0..=255).step_by(step) {
-            for j in (0..=255).step_by(step) {
-                for x in 0..8 {
-                    data[2 * x] = i;
-                    data[2 * x + 1] = j;
-                }
-                compute_context(BoundedSlice::new(&data).unwrap(), &mut context);
-                for x in 0..PRECOMPUTE_SIZE / 2 {
-                    let a = data[x + 1];
-                    let b = data[x];
-                    assert_eq!(
-                        context[x],
-                        CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize]
-                    );
-                }
-            }
-        }
-    }
+    // #[test]
+    // #[safe_arch_entrypoint("sse2", "ssse3", "sse4.1", "avx", "avx2")]
+    // fn test_compute_context() {
+    //     let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
+    //     let mut data = [0; 256];
+    //
+    //     let step = if cfg!(miri) { 10 } else { 1 };
+    //
+    //     for i in (0..=255).step_by(step) {
+    //         for j in (0..=255).step_by(step) {
+    //             for x in 0..8 {
+    //                 data[2 * x] = i;
+    //                 data[2 * x + 1] = j;
+    //             }
+    //             compute_context(BoundedSlice::new(&data).unwrap(), &mut context);
+    //             for x in 0..PRECOMPUTE_SIZE / 2 {
+    //                 let a = data[x + 1];
+    //                 let b = data[x];
+    //                 assert_eq!(
+    //                     context[x],
+    //                     CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize]
+    //                 );
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -845,12 +845,8 @@ impl<
 
 #[cfg(test)]
 mod test {
-    use super::{
-        _mm256_ilog2_epi32, compute_context, gain_from_len_and_dist, gain_from_len_and_dist_simd,
-        PRECOMPUTE_SIZE,
-    };
+    use super::{_mm256_ilog2_epi32, gain_from_len_and_dist, gain_from_len_and_dist_simd};
     use crate::constants::*;
-    use bounded_utils::{BoundedSlice, BoundedU8};
     use safe_arch_macro::safe_arch_entrypoint;
     use std::arch::x86_64::{_mm256_extract_epi32, _mm256_set1_epi32};
 

--- a/lib/src/hashtable.rs
+++ b/lib/src/hashtable.rs
@@ -887,31 +887,4 @@ mod test {
             }
         }
     }
-
-    // #[test]
-    // #[safe_arch_entrypoint("sse2", "ssse3", "sse4.1", "avx", "avx2")]
-    // fn test_compute_context() {
-    //     let mut context = [BoundedU8::constant::<0>(); PRECOMPUTE_SIZE];
-    //     let mut data = [0; 256];
-    //
-    //     let step = if cfg!(miri) { 10 } else { 1 };
-    //
-    //     for i in (0..=255).step_by(step) {
-    //         for j in (0..=255).step_by(step) {
-    //             for x in 0..8 {
-    //                 data[2 * x] = i;
-    //                 data[2 * x + 1] = j;
-    //             }
-    //             compute_context(BoundedSlice::new(&data).unwrap(), &mut context);
-    //             for x in 0..PRECOMPUTE_SIZE / 2 {
-    //                 let a = data[x + 1];
-    //                 let b = data[x];
-    //                 assert_eq!(
-    //                     context[x],
-    //                     CONTEXT_LUT0[a as usize] | CONTEXT_LUT1[b as usize]
-    //                 );
-    //             }
-    //         }
-    //     }
-    // }
 }

--- a/lib/src/map_to_sym.rs
+++ b/lib/src/map_to_sym.rs
@@ -190,7 +190,6 @@ pub fn insert_copy_len_to_sym_and_bits_simd<const SLICE_BOUND: usize, const INDE
     bits_buf: &mut [u64; 8],
     nbits_pat_buf: &mut [u64; 8],
     nbits_count_buf: &mut [u32; 8],
-    distance_ctx_buf: &mut [u32; 8],
 ) {
     const ZERO: BoundedUsize<0> = BoundedUsize::MAX;
     const FOUR: BoundedUsize<4> = BoundedUsize::MAX;
@@ -198,11 +197,6 @@ pub fn insert_copy_len_to_sym_and_bits_simd<const SLICE_BOUND: usize, const INDE
     let insert_len = safe_x86_64::_mm256_load(insert, index);
     let (insert_code, insert_nbits, insert_bits) = insert_len_to_sym_and_bits_simd(insert_len);
     let copy_len = safe_x86_64::_mm256_load(copy, index);
-    safe_x86_64::_mm256_store(
-        BoundedSlice::new_from_equal_array_mut(distance_ctx_buf),
-        ZERO,
-        _mm256_abs_epi32(_mm256_cmpgt_epi32(copy_len, _mm256_set1_epi32(4))),
-    );
 
     let (copy_code, copy_nbits, copy_bits) = copy_len_to_sym_and_bits_simd(copy_len);
 
@@ -343,7 +337,6 @@ pub fn distance_to_sym_and_bits_simd<
 >(
     distance: &BoundedSlice<u32, SLICE_BOUND>,
     pos: BoundedUsize<INDEX_BOUND>,
-    distance_ctx_buf: &[u32; 8],
     sym_buf: &mut [u32; 8],
     bits_buf: &mut [u32; 8],
     nbits_pat_buf: &mut [u32; 8],
@@ -397,15 +390,7 @@ pub fn distance_to_sym_and_bits_simd<
 
     const ZERO: BoundedUsize<0> = BoundedUsize::MAX;
 
-    let shifted_ctx = _mm256_slli_epi32::<LOG_MAX_DIST>(safe_x86_64::_mm256_load(
-        BoundedSlice::new_from_equal_array(distance_ctx_buf),
-        ZERO,
-    ));
-
-    let code = _mm256_add_epi32(
-        _mm256_add_epi32(_mm256_set1_epi32((SYMBOL_MASK + DIST_BASE) as i32), code),
-        shifted_ctx,
-    );
+    let code = _mm256_add_epi32(_mm256_set1_epi32((SYMBOL_MASK + DIST_BASE) as i32), code);
 
     let last_mask = _mm256_or_si256(last_matches, second_last_matches);
     let bits = _mm256_andnot_si256(last_mask, bits);
@@ -465,7 +450,6 @@ mod test {
     #[safe_arch_entrypoint("sse2", "avx", "avx2")]
     fn test_distance_simd() {
         let mut distances = [0u32; 1024];
-        let distance_ctx_buf = [0, 1, 0, 1, 0, 1, 0, 1];
         let mut distance_bits_buf = [0; 8];
         let mut distance_nbits_pat_buf = [0; 8];
         let mut distance_nbits_count_buf = [0; 8];
@@ -498,7 +482,6 @@ mod test {
             distance_to_sym_and_bits_simd::<1024, 0, 2>(
                 BoundedSlice::new_from_array(&distances),
                 BoundedUsize::MAX,
-                &distance_ctx_buf,
                 &mut distance_sym_buf,
                 &mut distance_bits_buf,
                 &mut distance_nbits_pat_buf,
@@ -516,8 +499,7 @@ mod test {
                     second_last_distance,
                 );
                 let adj_sym = sym as u16
-                    + (SYMBOL_MASK + DIST_BASE)
-                    + distance_ctx_buf[i] as u16 * MAX_DIST as u16;
+                    + (SYMBOL_MASK + DIST_BASE);
                 assert_eq!(adj_sym as u32, distance_sym_buf[i]);
                 assert_eq!(bits, distance_bits_buf[i]);
                 assert_eq!(
@@ -540,7 +522,6 @@ mod test {
         let mut bits_buf = [0; 8];
         let mut nbits_pat_buf = [0; 8];
         let mut nbits_count_buf = [0; 8];
-        let mut distance_ctx_buf = [0; 8];
 
         let step = if cfg!(miri) { 8 * 1000 } else { 8 };
 
@@ -564,7 +545,6 @@ mod test {
                     &mut bits_buf,
                     &mut nbits_pat_buf,
                     &mut nbits_count_buf,
-                    &mut distance_ctx_buf,
                 );
                 for x in 0..8 {
                     let (sym, nbits, bits) = insert_copy_len_to_sym_and_bits(insert[x], copy[x]);
@@ -574,7 +554,6 @@ mod test {
                         get_nbits(nbits_pat_buf[x], nbits_count_buf[x])
                     );
                     assert_eq!(bits, bits_buf[x]);
-                    assert_eq!(if copy[x] <= 4 { 0 } else { 1 }, distance_ctx_buf[x])
                 }
             }
         }

--- a/lib/src/map_to_sym.rs
+++ b/lib/src/map_to_sym.rs
@@ -498,8 +498,7 @@ mod test {
                     last_distance,
                     second_last_distance,
                 );
-                let adj_sym = sym as u16
-                    + (SYMBOL_MASK + DIST_BASE);
+                let adj_sym = sym as u16 + (SYMBOL_MASK + DIST_BASE);
                 assert_eq!(adj_sym as u32, distance_sym_buf[i]);
                 assert_eq!(bits, distance_bits_buf[i]);
                 assert_eq!(


### PR DESCRIPTION
This pr significantly speeds up the decompression speed at the expense of slightly bigger file sizes.
The compression time seems to remain unchanged, the difference ar within run to run variance.


| Branch | Input Size | Output Size | Ratio | Comp Iters | Comp Time ± SD | Comp Rate ± SD | Decomp Iters | Decomp Time ± SD | Decomp Rate |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| Main | 1100916957 | 286261324 | 3.846 | 60 | 16.467 ± 0.328 s/iter | 63.76 ± 1.27 MB/s | 60 | 2.840 ± 0.033 s/iter | 369.63 ± 4.31 MB/s |
| After pr | 1100916957 | 296909543 | 3.708 | 60 | 16.356 ± 0.939 s/iter | 64.19 ± 3.68 MB/s | 60 | 2.510 ± 0.032 s/iter | 418.22 ± 5.30 MB/s |
